### PR TITLE
tl test suite option accepts time without unit suffix (assumes to be …

### DIFF
--- a/scan_inputs_test.go
+++ b/scan_inputs_test.go
@@ -452,7 +452,7 @@ foo= bar
 		func(t *testing.T) {
 			text := `= foo
 foo= aaa
-tl=10.0
+tl=10.a
 ===
 
 ===
@@ -467,7 +467,7 @@ by the way...
 			errsWant := []error{
 				&cptest.LineRangeError{1, []string{"= foo"}, cptest.KeyMissing},
 				&cptest.LineRangeError{2, []string{"foo= aaa"}, &cptest.FieldError{"foo", cptest.ErrUnknownField}},
-				&cptest.LineRangeError{3, []string{"tl=10.0"}, &cptest.FieldError{"tl", &cptest.NotValueOfTypeError{"PositiveDuration", "10.0"}}},
+				&cptest.LineRangeError{3, []string{"tl=10.a"}, &cptest.FieldError{"tl", &cptest.NotValueOfTypeError{"PositiveDuration", "10.a"}}},
 				&cptest.LineRangeError{7, []string{"extra=love"}, &cptest.TestError{1, cptest.IOSeparatorMissing}},
 				&cptest.LineRangeError{9, []string{"oh = and", "by the way..."}, &cptest.TestError{2, cptest.IOSeparatorMissing}},
 			}

--- a/string_map_unmarshal.go
+++ b/string_map_unmarshal.go
@@ -75,6 +75,14 @@ func (d *PositiveDuration) UnmarshalText(b []byte) error {
 		return ErrNegativePositiveDuration
 	}
 
+    if err != nil {
+        num, err := strconv.ParseFloat(string(b), 64)
+        if err == nil {
+            *d = PositiveDuration{time.Duration(num * float64(time.Second))}
+            return nil
+        }
+    }
+
 	*d = PositiveDuration{dur}
 	return err
 }

--- a/string_map_unmarshal_test.go
+++ b/string_map_unmarshal_test.go
@@ -644,12 +644,28 @@ func TestPositiveDuration(t *testing.T) {
 		td.Cmp(t, dur.Duration, time.Second)
 	})
 
+	t.Run("one second without suffix", func(t *testing.T) {
+		dur := &cptest.PositiveDuration{}
+		err := dur.UnmarshalText([]byte("1"))
+
+		td.CmpNoError(t, err)
+		td.Cmp(t, dur.Duration, time.Second)
+	})
+
 	t.Run("ten seconds", func(t *testing.T) {
 		dur := &cptest.PositiveDuration{}
 		err := dur.UnmarshalText([]byte("10s"))
 
 		td.CmpNoError(t, err)
 		td.Cmp(t, dur.Duration, 10*time.Second)
+	})
+
+	t.Run("ten and half seconds without suffix", func(t *testing.T) {
+		dur := &cptest.PositiveDuration{}
+		err := dur.UnmarshalText([]byte("10.5"))
+
+		td.CmpNoError(t, err)
+		td.Cmp(t, dur.Duration, 10500 * time.Millisecond)
 	})
 
 	t.Run("1 and half milliseconds", func(t *testing.T) {


### PR DESCRIPTION
…seconds).