### PR TITLE
Emit warning for unknown configuration fields

### DIFF
--- a/_examples/08_bad_inputs/inputs2.txt
+++ b/_examples/08_bad_inputs/inputs2.txt
@@ -1,0 +1,14 @@
+foo = bar
+===
+
+===
+
+what the?
+---
+he
+
+===
+chu
+---
+chu
+

--- a/error_types.go
+++ b/error_types.go
@@ -16,6 +16,15 @@ func (e StringError) Error() string {
 	return string(e)
 }
 
+// StringWarning is same as StringError except it allows users to differentiate
+// warnings using errors.As
+type StringWarning string
+
+// Error prints the warning message.
+func (w StringWarning) Error() string {
+    return string(w)
+}
+
 // LineRangeError is used to amend information about the location of the error
 // within the source code. The source code lines in
 // question are stored in Lines (for printing purposes).

--- a/string_map_unmarshal.go
+++ b/string_map_unmarshal.go
@@ -18,7 +18,7 @@ const (
 
 	// ErrUnknownField is issued when the deserialization destination cannot be
 	// found in a struct-like via reflection.
-	ErrUnknownField = StringError("unknown field")
+	ErrUnknownField = StringWarning("unknown field")
 
 	// ErrNegativePositiveDuration is issued when PositiveDuration is attempted
 	// to be initialized with negative value.


### PR DESCRIPTION
Resolves #62 

Adds `StringWarning` type which users can detect via `errors.As`.