### PR TITLE
Fixed empty `inputs` on warnings in cli

### DIFF
--- a/cmd/scold/filesystem.go
+++ b/cmd/scold/filesystem.go
@@ -80,7 +80,7 @@ func readInputs(inputsPath string) (scold.Inputs, []error) {
 		for i, err := range errs {
 			errs[i] = fmt.Errorf("parse scold inputs file: %w", err)
 		}
-		return scold.Inputs{}, errs
+		return inputs, errs
 	}
 
 	return inputs, nil

--- a/cmd/scold/main.go
+++ b/cmd/scold/main.go
@@ -148,7 +148,7 @@ func init() {
 
 	scold.DefaultInputsConfig = scold.InputsConfig{
 		Tl:   scold.NewPositiveDuration(6 * time.Second),
-		Prec: 6,
+		Prec: 8,
 	}
 }
 

--- a/scan_inputs.go
+++ b/scan_inputs.go
@@ -191,7 +191,7 @@ func ScanInputs(text string) (inputs Inputs, errs []error) {
 		// Instead of incrementing lineNum at the code flow graph's each leaf,
 		// we'll do it once at the beginning.
 		if partNum != 0 {
-			// A part is a string between two lines that start with a specified
+			// A part is a string between two lines that starts with a specified
 			// prefix. We need to add excluded line with prefix to keep line number
 			// correct.
 			lineNum += strings.Count(parts[partNum-1], "\n") + 1
@@ -205,7 +205,7 @@ func ScanInputs(text string) (inputs Inputs, errs []error) {
 
 			if configErrs != nil {
 				errs = append(errs, configErrs...)
-				// We don't continue because ScanConfig gathers only correct
+				// We don't stop because ScanConfig gathers only correct
 				// key-value pairs.
 			}
 


### PR DESCRIPTION
Resolves #65 